### PR TITLE
feat(cli): added calibration model for precise drift detection

### DIFF
--- a/helm_inspect/cli.py
+++ b/helm_inspect/cli.py
@@ -9,8 +9,14 @@
 import argparse
 import shutil
 import sys
-from helm_inspect.core import check_drift
+import os
+import subprocess
+import json
+from datetime import datetime
 from art import text2art
+
+from helm_inspect.core import check_drift, get_ignorable_keys
+from helm_inspect.utils import IGNORABLE_KEYS
 
 
 def check_prerequisites():
@@ -27,6 +33,70 @@ def check_prerequisites():
         sys.exit(1)
 
 
+def get_cluster_name():
+    try:
+        result = subprocess.run(
+            [
+                "kubectl",
+                "config",
+                "view",
+                "--minify",
+                "-o",
+                "jsonpath={.clusters[0].name}",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except Exception:
+        return "unknown_cluster"
+
+
+def get_calibration_file(release, namespace, cluster):
+    tmp_dir = os.path.join(os.path.expanduser("~"), ".helminspect", "tmp")
+    os.makedirs(tmp_dir, exist_ok=True)
+    calibration_file = os.path.join(
+        tmp_dir, f"calibration_{release}_{namespace}_{cluster}.json"
+    )
+
+    if os.path.exists(calibration_file):
+        with open(calibration_file, "r") as f:
+            return json.load(f)
+
+    return None
+
+
+def save_calibration_data(ignorable_keys, release, namespace, cluster):
+    tmp_dir = os.path.join(os.path.expanduser("~"), ".helminspect", "tmp")
+    os.makedirs(tmp_dir, exist_ok=True)
+    calibration_file = os.path.join(
+        tmp_dir, f"calibration_{release}_{namespace}_{cluster}.json"
+    )
+
+    calibration_data = {
+        "date": datetime.utcnow().isoformat(),
+        "release": release,
+        "namespace": namespace,
+        "cluster": cluster,
+        "ignorable_keys": ignorable_keys,
+    }
+
+    with open(calibration_file, "w") as f:
+        json.dump(calibration_data, f, indent=2)
+
+
+def delete_calibration_file(release, namespace, cluster):
+    tmp_dir = os.path.join(os.path.expanduser("~"), ".helminspect", "tmp")
+    os.makedirs(tmp_dir, exist_ok=True)
+    calibration_file = os.path.join(
+        tmp_dir, f"calibration_{release}_{namespace}_{cluster}.json"
+    )
+
+    if os.path.exists(calibration_file):
+        os.remove(calibration_file)
+
+
 def main():
     print(text2art("Helm\nInspect", font="speed"))
 
@@ -37,9 +107,69 @@ def main():
     )
     parser.add_argument("--release", required=True, help="Helm release name")
     parser.add_argument("--namespace", required=True, help="Kubernetes namespace")
+    parser.add_argument(
+        "--calibrate",
+        action="store_true",
+        help="Calibrate HelmInspect to capture system-generated keys after a fresh Helm installation",
+    )
+    parser.add_argument(
+        "--no-ignore",
+        action="store_true",
+        help="Disable key ignoring for strict drift detection (shows all differences including system-generated keys)",
+    )
+
     args = parser.parse_args()
 
-    check_drift(args.release, args.namespace)
+    cluster_name = get_cluster_name()
+
+    if args.no_ignore and args.calibrate:
+        print(
+            "❌ Cannot use --no-ignore with --calibrate. The --calibrate flag is used to identify keys to ignore, "
+            "while --no-ignore explicitly disables this feature. Please use only one of these flags."
+        )
+        return
+
+    if args.calibrate:
+        delete_calibration_file(args.release, args.namespace, cluster_name)
+        print("✅ Calibration data deleted.")
+
+        ignorable_keys = get_ignorable_keys(args.release, args.namespace)
+        save_calibration_data(
+            ignorable_keys, args.release, args.namespace, cluster_name
+        )
+        print("✅ New calibration data saved with ignorable keys.")
+
+        return
+
+    calibration_data = get_calibration_file(args.release, args.namespace, cluster_name)
+
+    if calibration_data:
+        try:
+            calibration_date = datetime.fromisoformat(calibration_data["date"])
+            days_old = (datetime.utcnow() - calibration_date).days
+            if days_old > 30:
+                print(
+                    f"WARNING: Calibration data is {days_old} days old. Consider recalibrating for accurate drift detection. \n"
+                )
+        except (KeyError, ValueError):
+            print("ERROR: Calibration data format is invalid. Consider recalibrating.")
+
+    if args.no_ignore:
+        print("✅ Proceeding without ignoring any keys.")
+        ignorable_keys = None
+    elif calibration_data:
+        print("✅ Using existing calibration data.")
+        ignorable_keys = calibration_data["ignorable_keys"]
+    else:
+        print(
+            "CAUTION: No calibration data found for this release/namespace/cluster combination!\n\n"
+            "  • Using default ignorable keys which may not be accurate for your environment\n"
+            f"  • For best results, run 'helm-inspect --calibrate --release {args.release} --namespace {args.namespace}'\n"
+            "    immediately after a fresh Helm installation when you know there is no drift\n"
+            "  • This creates a profile of system-generated keys specific to your cluster"
+        )
+        ignorable_keys = IGNORABLE_KEYS.copy()
+    check_drift(args.release, args.namespace, ignorable_keys)
 
 
 if __name__ == "__main__":

--- a/helm_inspect/core.py
+++ b/helm_inspect/core.py
@@ -15,8 +15,61 @@ from helm_inspect.utils import (
 )
 
 
-def compare_values(helm_manifest, namespace):
+def extract_keys_recursive(data, parent_key=""):
+    keys = set()
+    if isinstance(data, dict):
+        for key, value in data.items():
+            full_key = f"{parent_key}.{key}" if parent_key else key
+            keys.add(full_key)
+            keys.update(extract_keys_recursive(value, full_key))
+    elif isinstance(data, list):
+        for index, item in enumerate(data):
+            keys.update(
+                extract_keys_recursive(item, f"{parent_key}[{index}]")
+                if parent_key
+                else extract_keys_recursive(item)
+            )
+    return keys
+
+
+def get_ignorable_keys(release, namespace):
+    helm_manifest = get_helm_manifest(release, namespace)
+    ignorable_keys = set()
+    resource_count = 0
+
+    print(f"🔍 Analyzing {len(helm_manifest)} resources for calibration...")
+
     for resource in helm_manifest:
+        if not resource:
+            continue
+
+        kind = resource.get("kind", "Unknown")
+        name = resource.get("metadata", {}).get("name", "Unknown")
+
+        print(f"  📊 Processing {kind}/{name}...", end="\r")
+
+        live_resource = get_k8s_resource(kind, name, namespace)
+        if not live_resource:
+            continue
+
+        helm_keys = extract_keys_recursive(extract_relevant_data(resource, None))
+        live_keys = extract_keys_recursive(extract_relevant_data(live_resource, None))
+
+        ignorable_keys.update(live_keys - helm_keys)
+        resource_count += 1
+
+    print(
+        f"✅ Analyzed {resource_count} resources and found {len(ignorable_keys)} drift-prone keys."
+    )
+
+    return list(ignorable_keys)
+
+
+def compare_values(helm_manifest, namespace, ignorable_keys):
+    for resource in helm_manifest:
+        if not resource:
+            continue
+
         kind = resource.get("kind", "Unknown")
         name = resource.get("metadata", {}).get("name", "Unknown")
 
@@ -30,8 +83,8 @@ def compare_values(helm_manifest, namespace):
             print(f"❌ Drift detected: {kind} `{name}` is missing in Kubernetes.")
             continue
 
-        helm_data = extract_relevant_data(resource)
-        live_data = extract_relevant_data(live_resource)
+        helm_data = extract_relevant_data(resource, ignorable_keys)
+        live_data = extract_relevant_data(live_resource, ignorable_keys)
 
         helm_json = json.dumps(helm_data, indent=2, sort_keys=True)
         live_json = json.dumps(live_data, indent=2, sort_keys=True)
@@ -52,11 +105,11 @@ def compare_values(helm_manifest, namespace):
             print(f"✅ No drift detected in {kind} `{name}`.")
 
 
-def check_drift(release, namespace):
+def check_drift(release, namespace, ignorable_keys):
     helm_manifest = get_helm_manifest(release, namespace)
 
     if not helm_manifest:
         print("⚠️ No Helm manifest found. Ensure the release exists and try again.")
         return
 
-    compare_values(helm_manifest, namespace)
+    compare_values(helm_manifest, namespace, ignorable_keys)


### PR DESCRIPTION
## Description

- Users can now add the `--calibrate` flag to calibrate a Helm installation. This process captures system-generated keys that Kubernetes might add to the deployed resources, preventing them from being mistakenly flagged as drift during comparisons. The calibration data is stored in the `.helminspect/tmp` folder and is automatically used in future drift detection runs.  

- Users who prefer a raw comparison without ignoring any additional keys can pass the `--no-ignore` flag. This disables calibration, ensuring that all differences between the Helm manifest and the Kubernetes resources are reported, including system-generated keys.  

- A warning message will be displayed to inform users about the impact of using calibration or disabling it. This ensures clarity on how drift detection results are affected by system-generated changes.

## Related Issue

- [x] Link to the related issue #2 

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Documentation

## Checklist

- [x] Code follows the project style guidelines
- [ ] Tests have been added/updated
- [ ] All tests pass



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a calibration mode with additional command-line options, allowing users to update calibration data and selectively disable default key filtering during drift detection.
  
- **Improvements**
  - Enhanced the drift detection process by dynamically filtering non-relevant configuration keys.
  - Improved data extraction from nested resource structures and strengthened error handling around cluster identification and calibration data management.
  - Added support for specifying ignorable keys during data extraction and comparison processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->