### PR TITLE
fix(landing): mobile layout patch for how, why sections

### DIFF
--- a/landing/src/components/layout/layout.styles.ts
+++ b/landing/src/components/layout/layout.styles.ts
@@ -11,7 +11,7 @@ export const LayoutWrapper = styled.div`
 export const LayoutContent = styled.div`
     display: flex;
     flex-direction: column;
-    gap: 2rem;
+    gap: 5rem;
     width: 100%;
     height: 100%;
     overflow-y: auto;

--- a/landing/src/containers/how/how.styles.ts
+++ b/landing/src/containers/how/how.styles.ts
@@ -11,6 +11,7 @@ export const HowWrapper = styled.div`
 
     @media (max-width: 1024px) {
         padding: 0;
+        margin-bottom: 5rem;
     }
 `
 
@@ -22,7 +23,8 @@ export const HowContent = styled.div`
     width: 100%;
 
     @media (max-width: 1024px) {
-        grid-template-columns: 1fr;
+        display: flex;
+        flex-direction: column-reverse;
         height: auto;
     }
 `

--- a/landing/src/containers/why/why.styles.ts
+++ b/landing/src/containers/why/why.styles.ts
@@ -22,6 +22,7 @@ export const WhyContent = styled.div`
     width: 100%;
 
     @media (max-width: 1024px) {
-        grid-template-columns: 1fr;
+        display: flex;
+        flex-direction: column;
     }
 `


### PR DESCRIPTION
## Description

- Ensuring both sections follow the same order for `ScenarioBox` and `CTABox` to maintain visual and structural consistency, making the user experience more intuitive.
- Adjusted spacing to be more even and visually comfortable.
- Maintaining a consistent margin/padding strategy across sections.

## Related Issue

- [x] Link to the related issue #13 

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Documentation

## Checklist

- [x] Code follows the project style guidelines
- [ ] Tests have been added/updated
- [ ] All tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Increased spacing between elements for a more balanced layout.
  - Improved mobile responsiveness by adjusting vertical spacing and stacking order on smaller screens.
  - Transitioned some components from a grid structure to a flex layout, enhancing display consistency across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->